### PR TITLE
installation via conda

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: sbpiper
-Version: 1.2.0
-Date: 2018-02-14
+Version: 1.3.0
+Date: 2018-02-15
 Title: Data Analysis Functions for SBpipe Package
 Author: Piero Dalle Pezze
 Maintainer: Piero Dalle Pezze <piero.dallepezze@gmail.com>

--- a/NEWS
+++ b/NEWS
@@ -1,8 +1,10 @@
 
-v1.2.0
+v1.3.0
 
 - code optimisation
 - fixed versions for dependency packages installed via conda
+- r-colorramps is now distributed in the conda channel pdp10 and depends on r-base in r channel. 
+This removes dependency conflicts between r-base versions between r and conda-forge channels.
 
 
 v1.0.0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ SBpiper can directly be installed via github:
 
 or via conda:
 ```
-$ conda install sbpiper -c pdp10 -c r -c defaults -c conda-forge 
+$ conda install sbpiper -c pdp10 -c r -c defaults
 ```
 
 The R package is loaded as usual:
@@ -47,14 +47,15 @@ $ R CMD INSTALL sbpiper_X.Y.Z.tar.gz
 ```
 
 ## How to build this package (for developers)
-Conda recipe for SBpiper retrieves the code from the github branch: `master`. Therefore, before building the conda package, make sure that this branch is updated with the new version. Anaconda client is needed and can be installed with the following commands:
+Conda recipe for SBpiper retrieves the code from the github branch: `develop`. 
+Anaconda client is needed and can be installed with the following commands:
 ```
 $ conda install anaconda-client
 $ anaconda login
 ```
 Build conda package:
 ```
-$ conda-build conda_recipe/meta.yaml -c pdp10 -c r -c defaults -c conda-forge
+$ conda-build conda_recipe/meta.yaml -c pdp10 -c r -c defaults
 ```
 
 

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -14,7 +14,7 @@
 # along with sbpipe.  If not, see <http://www.gnu.org/licenses/>.
 
 
-{% set version= '1.2.0' %}
+{% set version= '1.3.0' %}
 
 package:
   name: sbpiper
@@ -39,23 +39,20 @@ build:
 
 requirements:
     build:
-        # r-colorramps is in conda-forge channel. Put this on top, so that 
-        # r-base will be reinstalled from the r channel when the following dependencies 
-        # will be parsed
-        - r-colorramps    
-        - r-base=3.4.1
+        - r-base=3.4.2
         - r-data.table
         - r-ggplot2>=2.2.0
         - r-reshape2
         - r-scales
+        - r-colorramps        
         #- r-essentials       
     run:
-        - r-colorramps    
-        - r-base=3.4.1    
+        - r-base=3.4.2    
         - r-data.table
         - r-ggplot2>=2.2.0
         - r-reshape2
         - r-scales
+        - r-colorramps        
         #- r-essentials       
 test:
     commands:

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -21,7 +21,7 @@ package:
   version: {{ version }}
 
 source:
-  git_rev: master
+  git_rev: develop
   git_url: https://github.com/pdp10/sbpiper.git
   #path: ../
   
@@ -39,20 +39,23 @@ build:
 
 requirements:
     build:
+        # r-colorramps is in conda-forge channel. Put this on top, so that 
+        # r-base will be reinstalled from the r channel when the following dependencies 
+        # will be parsed
+        - r-colorramps    
         - r-base=3.4.1
         - r-data.table
-        - r-ggplot2=2.2.1
+        - r-ggplot2>=2.2.0
         - r-reshape2
         - r-scales
-        - r-colorramps=2.3
         #- r-essentials       
     run:
+        - r-colorramps    
         - r-base=3.4.1    
         - r-data.table
-        - r-ggplot2=2.2.1
+        - r-ggplot2>=2.2.0
         - r-reshape2
         - r-scales
-        - r-colorramps=2.3
         #- r-essentials       
 test:
     commands:

--- a/environment.yaml
+++ b/environment.yaml
@@ -23,11 +23,14 @@ channels:
   - defaults
   - conda-forge  
 dependencies:
+  # r-colorramps is in conda-forge channel. Put this on top, so that 
+  # r-base will be reinstalled from the r channel when the following dependencies 
+  # will be parsed
+  - r-colorramps
   - r-base=3.4.1
   - r-data.table
-  - r-ggplot2=2.2.1
+  - r-ggplot2>=2.2.0
   - r-reshape2
   - r-scales
-  - r-colorramps=2.3
   #- r-essentials
   

--- a/environment.yaml
+++ b/environment.yaml
@@ -19,10 +19,9 @@
 name:
   - sbpiper
 channels:
-  - r
   - pdp10        # r-colorramps
+  - r
   - defaults
-#  - conda-forge  
 dependencies:
   - r-base=3.4.2
   - r-data.table

--- a/environment.yaml
+++ b/environment.yaml
@@ -21,16 +21,13 @@ name:
 channels:
   - r
   - defaults
-  - conda-forge  
+#  - conda-forge  
 dependencies:
-  # r-colorramps is in conda-forge channel. Put this on top, so that 
-  # r-base will be reinstalled from the r channel when the following dependencies 
-  # will be parsed
-  - r-colorramps
-  - r-base=3.4.1
+  - r-base=3.4.2
   - r-data.table
   - r-ggplot2>=2.2.0
   - r-reshape2
   - r-scales
+  - r-colorramps  
   #- r-essentials
   

--- a/environment.yaml
+++ b/environment.yaml
@@ -20,6 +20,7 @@ name:
   - sbpiper
 channels:
   - r
+  - pdp10        # r-colorramps
   - defaults
 #  - conda-forge  
 dependencies:


### PR DESCRIPTION
This pull request fixes the installation of SBpipe via conda. The main issue was in sbpiper (R package for data analysis used by SBpipe - see https://github.com/pdp10/sbpiper ). Whilst sbpiper depends on conda packages within the r channel, the dependency r-colorramps was stored in the conda-forge channel. This caused a conflict with the version of r-base which is stored in both r and conda-forge channel, and there was no option to force the retrieval of this package from one specific channel.
To solve this issue, a conda package for r-colorramps was created and stored in pdp10 channel (the channel where sbpipe and sbpiper are stored). This pdp10::r-colorramps depends on r::r-base, so there is no possibility of version conflict regarding sbpiper.

This pull request updates the documentation regarding the installation of sbpipe and sbpiper using conda, and adds a script for the creation of a conda package for r-colorramps.